### PR TITLE
Update Octokit.fsx

### DIFF
--- a/modules/Octokit/Octokit.fsx
+++ b/modules/Octokit/Octokit.fsx
@@ -1,8 +1,8 @@
 #nowarn "211"
 #I __SOURCE_DIRECTORY__
-#I @"../../../../../packages/Octokit/lib/net45"
-#I @"../../packages/Octokit/lib/net45"
-#I @"../../../../../../packages/build/Octokit/lib/net45"
+#I @"../../../../../packages/Octokit/lib/net46"
+#I @"../../packages/Octokit/lib/net46"
+#I @"../../../../../../packages/build/Octokit/lib/net46"
 #r "System.Net.Http"
 #r "Octokit.dll"
 


### PR DESCRIPTION
octokit got updated to work with net46, so the paths need to be updated in order to pick up the dependency.

### Description

Please give a brief explanation about your change.

If available, link to an existing issue this PR fixes. For example:

- fixes #1234

## TODO

Feel free to open the PR and ask for help

- [ ] New (API-)documentation for new features exist (Note: API-docs are enough, additional docs are in `help/markdown`)
- [ ] unit or integration test exists (or short reasoning why it doesn't make sense)
  
  > Note: Consider using the `CreateProcess` API which can be tested more easily, see https://github.com/fsharp/FAKE/pull/2131/files#diff-4fb4a77e110fbbe8210205dfe022389b for an example (the changes in the `DotNet.Testing.NUnit` module)
  
- [ ] boy scout rule: "leave the code behind in a better state than you found it" (fix warnings, obsolete members or code-style in the places you worked in)     
- [ ] (if new module) the module has been linked from the "Modules" menu, edit `help/templates/template.cshtml`, linking to the API-reference is fine.
- [ ] (if new module) the module is in the correct namespace
- [x] (if new module) the module is added to Fake.sln (`dotnet sln Fake.sln add src/app/Fake.*/Fake.*.fsproj`)
- [x] Fake 5 [API guideline](https://fake.build/contributing.html#API-Design-Guidelines) is honored
